### PR TITLE
Revert to using a version of colors that exists

### DIFF
--- a/src/app/auth-workflow/CHANGELOG.md
+++ b/src/app/auth-workflow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v2.0.5 (July 22, 2021)
+## v2.0.4 (July 22, 2021)
 
 ### Fixed
 

--- a/src/app/auth-workflow/CHANGELOG.md
+++ b/src/app/auth-workflow/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.0.5 (July 22, 2021)
+
+### Fixed
+
+-   Fixed missing @pxblue/colors dependency version.
+
 ## v2.0.3 (July 14, 2021)
 
 ### Changed

--- a/src/app/auth-workflow/package.json
+++ b/src/app/auth-workflow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pxblue/angular-template-authentication",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "keywords": [
         "angular",
         "template",

--- a/src/app/auth-workflow/template-dependencies.json
+++ b/src/app/auth-workflow/template-dependencies.json
@@ -6,7 +6,7 @@
         "@angular/flex-layout@^11.0.0-beta.33",
         "@angular/material@^11.0.3",
         "@angular/animations@^11.0.3",
-        "@pxblue/colors@^3.1.0",
+        "@pxblue/colors@^3.0.0",
         "@pxblue/angular-auth-workflow@^2.2.0"
     ]
 }

--- a/src/app/blank/CHANGELOG.md
+++ b/src/app/blank/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.4 (July 22, 2021)
+
+### Fixed
+
+-   Fixed missing @pxblue/colors dependency version.
+
 ## v1.0.3 (July 14, 2021)
 
 ### Changed

--- a/src/app/blank/package.json
+++ b/src/app/blank/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pxblue/angular-template-blank",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "keywords": [
         "angular",
         "template",

--- a/src/app/blank/template-dependencies.json
+++ b/src/app/blank/template-dependencies.json
@@ -6,6 +6,6 @@
         "@angular/flex-layout@^11.0.0-beta.33",
         "@angular/material@^11.0.3",
         "@angular/animations@^11.0.3",
-        "@pxblue/colors@^3.1.0"
+        "@pxblue/colors@^3.0.0"
     ]
 }

--- a/src/app/routing/CHANGELOG.md
+++ b/src/app/routing/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.5 (July 22, 2021)
+
+### Fixed
+
+-   Fixed missing @pxblue/colors dependency version.
+
 ## v1.0.4 (July 14, 2021)
 
 ### Changed

--- a/src/app/routing/package.json
+++ b/src/app/routing/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pxblue/angular-template-routing",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "keywords": [
         "angular",
         "template",

--- a/src/app/routing/template-dependencies.json
+++ b/src/app/routing/template-dependencies.json
@@ -6,6 +6,6 @@
         "@angular/flex-layout@^11.0.0-beta.33",
         "@angular/material@^11.0.3",
         "@angular/animations@^11.0.3",
-        "@pxblue/colors@^3.1.0"
+        "@pxblue/colors@^3.0.0"
     ]
 }


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Use a version of @pxblue/colors that exists. 